### PR TITLE
trakt-java 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+4.2.1 *(2015-02-05)*
+--------------------
+
+ * switch to [new API endpoint](http://docs.trakt.apiary.io/#introduction/api-url) `https://api-v2launch.trakt.tv` from `https://api.trakt.tv`
+ * For `BaseShow`, `collected_at` is now `last_collected_at`, added `last_watched_at`.
+ * Tests allow empty cast character name.
+
 4.2.0 *(2015-02-04)*
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 Add the following dependency to your Gradle project:
 
 ```groovy
-compile 'com.uwetrottmann:trakt-java:4.2.0'
+compile 'com.uwetrottmann:trakt-java:4.2.1'
 ```
 
 Or for Maven:
@@ -22,7 +22,7 @@ Or for Maven:
 <dependency>
   <groupId>com.uwetrottmann</groupId>
   <artifactId>trakt-java</artifactId>
-  <version>4.2.0</version>
+  <version>4.2.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.uwetrottmann</groupId>
     <artifactId>trakt-java</artifactId>
     <packaging>jar</packaging>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
 
     <name>trakt-java</name>
     <description>A Java wrapper around the trakt v2 API using retrofit.</description>

--- a/src/main/java/com/uwetrottmann/trakt/v2/TraktV2.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/TraktV2.java
@@ -50,7 +50,7 @@ public class TraktV2 {
      * trakt API v2 URL.
      */
     public static final String SITE_URL = "https://trakt.tv";
-    public static final String API_URL = "https://api.trakt.tv";
+    public static final String API_URL = "https://api-v2launch.trakt.tv";
     public static final String HEADER_TRAKT_API_VERSION_2 = "2";
     public static final String HEADER_CONTENT_TYPE_JSON = "application/json";
 

--- a/src/main/java/com/uwetrottmann/trakt/v2/entities/BaseShow.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/entities/BaseShow.java
@@ -12,11 +12,12 @@ public class BaseShow {
     public List<BaseSeason> seasons;
 
     /** collection */
-    public DateTime collected_at;
+    public DateTime last_collected_at;
     /** watchlist */
     public DateTime listed_at;
     /** watched */
     public Integer plays;
+    public DateTime last_watched_at;
     /** progress */
     public Integer aired;
     /** progress */

--- a/src/test/java/com/uwetrottmann/trakt/v2/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/BaseTestCase.java
@@ -95,7 +95,7 @@ public class BaseTestCase {
 
     public void assertCast(Credits credits, Type type) {
         for (CastMember castMember : credits.cast) {
-            assertThat(castMember.character).isNotEmpty();
+            assertThat(castMember.character).isNotNull();
             if (type == Type.SHOW) {
                 assertThat(castMember.movie).isNull();
                 assertThat(castMember.show).isNotNull();

--- a/src/test/java/com/uwetrottmann/trakt/v2/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/BaseTestCase.java
@@ -73,9 +73,10 @@ public class BaseTestCase {
         for (BaseShow show : shows) {
             assertThat(show.show).isNotNull();
             if ("collection".equals(type)) {
-                assertThat(show.collected_at).isNotNull();
+                assertThat(show.last_collected_at).isNotNull();
             } else if ("watched".equals(type)) {
                 assertThat(show.plays).isPositive();
+                assertThat(show.last_watched_at).isNotNull();
             }
 
             for (BaseSeason season : show.seasons) {

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/EpisodesTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/EpisodesTest.java
@@ -26,7 +26,7 @@ public class EpisodesTest extends BaseTestCase {
     @Test
     public void test_comments() {
         getTrakt().episodes().comments(TestData.SHOW_SLUG, TestData.EPISODE_SEASON, TestData.EPISODE_NUMBER,
-                1, DEFAULT_PAGE_SIZE, Extended.IMAGES);
+                1, DEFAULT_PAGE_SIZE, Extended.DEFAULT_MIN);
     }
 
     @Test

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/MoviesTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/MoviesTest.java
@@ -86,7 +86,7 @@ public class MoviesTest extends BaseTestCase {
 
     @Test
     public void test_comments() {
-        List<Comment> comments = getTrakt().movies().comments(TestData.MOVIE_SLUG, 1, null, Extended.IMAGES);
+        List<Comment> comments = getTrakt().movies().comments(TestData.MOVIE_SLUG, 1, null, Extended.DEFAULT_MIN);
         assertThat(comments.size()).isLessThanOrEqualTo(DEFAULT_PAGE_SIZE);
     }
 

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/MoviesTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/MoviesTest.java
@@ -21,7 +21,7 @@ public class MoviesTest extends BaseTestCase {
 
     @Test
     public void test_popular() {
-        List<Movie> movies = getTrakt().movies().popular(2, null, Extended.FULLIMAGES);
+        List<Movie> movies = getTrakt().movies().popular(2, null, Extended.DEFAULT_MIN);
         assertThat(movies.size()).isLessThanOrEqualTo(DEFAULT_PAGE_SIZE);
         for (Movie movie : movies) {
             assertMovieNotNull(movie);
@@ -30,7 +30,7 @@ public class MoviesTest extends BaseTestCase {
 
     @Test
     public void test_trending() {
-        List<TrendingMovie> movies = getTrakt().movies().trending(1, null, Extended.FULLIMAGES);
+        List<TrendingMovie> movies = getTrakt().movies().trending(1, null, Extended.DEFAULT_MIN);
         assertThat(movies.size()).isLessThanOrEqualTo(DEFAULT_PAGE_SIZE);
         for (TrendingMovie movie : movies) {
             assertThat(movie.watchers).isNotNull();

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/RecommendationsTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/RecommendationsTest.java
@@ -15,13 +15,13 @@ public class RecommendationsTest extends BaseTestCase {
 
     @Test
     public void test_movies() throws OAuthUnauthorizedException {
-        List<Movie> movies = getTrakt().recommendations().movies(Extended.FULLIMAGES);
+        List<Movie> movies = getTrakt().recommendations().movies(Extended.DEFAULT_MIN);
         assertThat(movies).isNotEmpty();
     }
 
     @Test
     public void test_shows() throws OAuthUnauthorizedException {
-        List<Show> shows = getTrakt().recommendations().shows(Extended.FULLIMAGES);
+        List<Show> shows = getTrakt().recommendations().shows(Extended.DEFAULT_MIN);
         assertThat(shows).isNotEmpty();
     }
 

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/SeasonsTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/SeasonsTest.java
@@ -22,7 +22,7 @@ public class SeasonsTest extends BaseTestCase {
 
     @Test
     public void test_season() {
-        List<Episode> season = getTrakt().seasons().season(TestData.SHOW_SLUG, TestData.EPISODE_SEASON, Extended.FULLIMAGES);
+        List<Episode> season = getTrakt().seasons().season(TestData.SHOW_SLUG, TestData.EPISODE_SEASON, Extended.DEFAULT_MIN);
         assertThat(season).isNotEmpty();
         for (Episode episode : season) {
             assertThat(episode.season).isEqualTo(TestData.EPISODE_SEASON);

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/ShowsTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/ShowsTest.java
@@ -91,7 +91,7 @@ public class ShowsTest extends BaseTestCase {
 
     @Test
     public void test_comments() {
-        List<Comment> comments = getTrakt().shows().comments(TestData.SHOW_SLUG, 1, null, Extended.IMAGES);
+        List<Comment> comments = getTrakt().shows().comments(TestData.SHOW_SLUG, 1, null, Extended.DEFAULT_MIN);
         assertThat(comments.size()).isLessThanOrEqualTo(DEFAULT_PAGE_SIZE);
     }
 

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/ShowsTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/ShowsTest.java
@@ -24,7 +24,7 @@ public class ShowsTest extends BaseTestCase {
 
     @Test
     public void test_popular() {
-        List<Show> shows = getTrakt().shows().popular(2, null, Extended.FULLIMAGES);
+        List<Show> shows = getTrakt().shows().popular(2, null, Extended.DEFAULT_MIN);
         assertThat(shows.size()).isLessThanOrEqualTo(DEFAULT_PAGE_SIZE);
         for (Show show : shows) {
             assertShowNotNull(show);
@@ -33,7 +33,7 @@ public class ShowsTest extends BaseTestCase {
 
     @Test
     public void test_trending() {
-        List<TrendingShow> shows = getTrakt().shows().trending(1, null, Extended.FULLIMAGES);
+        List<TrendingShow> shows = getTrakt().shows().trending(1, null, Extended.DEFAULT_MIN);
         assertThat(shows.size()).isLessThanOrEqualTo(DEFAULT_PAGE_SIZE);
         for (TrendingShow show : shows) {
             assertThat(show.watchers).isNotNull();


### PR DESCRIPTION
- switch to [new API endpoint](http://docs.trakt.apiary.io/#introduction/api-url) `https://api-v2launch.trakt.tv` from `https://api.trakt.tv`
- For `BaseShow`, `collected_at` is now `last_collected_at`, added `last_watched_at`.
- Tests allow empty cast character name.