### PR TITLE
Update Episode

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt/v2/entities/Episode.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/entities/Episode.java
@@ -11,6 +11,5 @@ public class Episode extends BaseEntity {
     // extended info
     public Integer number_abs;
     public DateTime first_aired;
-    public Double rating;
 
 }


### PR DESCRIPTION
Quick fix to remove `rating` in Episode as it is now present in BaseEntity.