### PR TITLE
Allow checking in with show, season and episode

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt/v2/entities/EpisodeCheckin.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/entities/EpisodeCheckin.java
@@ -2,10 +2,12 @@ package com.uwetrottmann.trakt.v2.entities;
 
 public class EpisodeCheckin extends BaseCheckin {
 
+    public Show show;
     public SyncEpisode episode;
 
     public static class Builder {
 
+        private Show show;
         private SyncEpisode episode;
         protected ShareSettings sharing;
         protected String message;
@@ -21,6 +23,11 @@ public class EpisodeCheckin extends BaseCheckin {
             this.episode = episode;
             this.app_version = appVersion;
             this.app_date = appDate;
+        }
+
+        public Builder show(Show show) {
+            this.show = show;
+            return this;
         }
 
         public Builder sharing(ShareSettings shareSettings) {
@@ -45,6 +52,7 @@ public class EpisodeCheckin extends BaseCheckin {
 
         public EpisodeCheckin build() {
             EpisodeCheckin checkin = new EpisodeCheckin();
+            checkin.show = show;
             checkin.episode = episode;
             checkin.sharing = sharing;
             checkin.message = message;

--- a/src/main/java/com/uwetrottmann/trakt/v2/entities/SyncEpisode.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/entities/SyncEpisode.java
@@ -5,6 +5,7 @@ import org.joda.time.DateTime;
 
 public class SyncEpisode {
 
+    public Integer season;
     public Integer number;
     public EpisodeIds ids;
 
@@ -15,6 +16,11 @@ public class SyncEpisode {
 
     public SyncEpisode number(int number) {
         this.number = number;
+        return this;
+    }
+
+    public SyncEpisode season(int season) {
+        this.season = season;
         return this;
     }
 

--- a/src/test/java/com/uwetrottmann/trakt/v2/services/CheckinTest.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/services/CheckinTest.java
@@ -2,7 +2,16 @@ package com.uwetrottmann.trakt.v2.services;
 
 import com.uwetrottmann.trakt.v2.BaseTestCase;
 import com.uwetrottmann.trakt.v2.TestData;
-import com.uwetrottmann.trakt.v2.entities.*;
+import com.uwetrottmann.trakt.v2.entities.EpisodeCheckin;
+import com.uwetrottmann.trakt.v2.entities.EpisodeCheckinResponse;
+import com.uwetrottmann.trakt.v2.entities.EpisodeIds;
+import com.uwetrottmann.trakt.v2.entities.MovieCheckin;
+import com.uwetrottmann.trakt.v2.entities.MovieCheckinResponse;
+import com.uwetrottmann.trakt.v2.entities.MovieIds;
+import com.uwetrottmann.trakt.v2.entities.ShareSettings;
+import com.uwetrottmann.trakt.v2.entities.Show;
+import com.uwetrottmann.trakt.v2.entities.SyncEpisode;
+import com.uwetrottmann.trakt.v2.entities.SyncMovie;
 import com.uwetrottmann.trakt.v2.exceptions.CheckinInProgressException;
 import com.uwetrottmann.trakt.v2.exceptions.OAuthUnauthorizedException;
 import org.joda.time.DateTime;
@@ -33,14 +42,7 @@ public class CheckinTest extends BaseTestCase {
         // delete check-in first
         test_checkin_delete();
 
-        assertThat(response).isNotNull();
-        // episode should be over in less than an hour
-        assertThat(response.watched_at).isBefore(new DateTime().plusHours(1));
-        assertThat(response.episode).isNotNull();
-        assertThat(response.episode.ids).isNotNull();
-        assertThat(response.episode.ids.trakt).isEqualTo(TestData.EPISODE_TRAKT_ID);
-        assertThat(response.episode.ids.tvdb).isEqualTo(TestData.EPISODE_TVDB_ID);
-        assertThat(response.show).isNotNull();
+        assertEpisodeCheckin(response);
     }
 
     @Test
@@ -57,6 +59,10 @@ public class CheckinTest extends BaseTestCase {
         // delete check-in first
         test_checkin_delete();
 
+        assertEpisodeCheckin(response);
+    }
+
+    private void assertEpisodeCheckin(EpisodeCheckinResponse response) {
         assertThat(response).isNotNull();
         // episode should be over in less than an hour
         assertThat(response.watched_at).isBefore(new DateTime().plusHours(1));


### PR DESCRIPTION
Allow checking in with show, season and episode without needing EpisodeIds.

Added Show to EpisodeCheckin to allow searching by name, ids etc.. as per the [docs example](http://docs.trakt.apiary.io/#reference/checkin/checkin/check-into-an-item)

Added season number to SyncEpisode