### PR TITLE
added last_watched_at to BaseEpisode

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt/v2/entities/BaseEpisode.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/entities/BaseEpisode.java
@@ -10,6 +10,7 @@ public class BaseEpisode {
     public DateTime collected_at;
     /** watched */
     public Integer plays;
+    public DateTime last_watched_at;
     /** progress */
     public Boolean completed;
 

--- a/src/test/java/com/uwetrottmann/trakt/v2/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt/v2/BaseTestCase.java
@@ -88,6 +88,7 @@ public class BaseTestCase {
                         assertThat(episode.collected_at).isNotNull();
                     } else if ("watched".equals(type)) {
                         assertThat(episode.plays).isPositive();
+                        assertThat(episode.last_watched_at).isNotNull();
                     }
                 }
             }


### PR DESCRIPTION
The class BaseEpisode (for fetching watched states from trakt.tv - service /sync/watched/shows ) did not contain the field last_watched_at