### PR TITLE
Support for "shows" and "seasons" in HistoryType

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt/v2/enums/HistoryType.java
+++ b/src/main/java/com/uwetrottmann/trakt/v2/enums/HistoryType.java
@@ -3,6 +3,8 @@ package com.uwetrottmann.trakt.v2.enums;
 public enum HistoryType implements TraktEnum {
 
     MOVIES("movies"),
+    SHOWS("shows"),
+    SEASONS("seasons"),
     EPISODES("episodes");
 
     private final String value;


### PR DESCRIPTION
As per current API (http://docs.trakt.apiary.io/#reference/users/history/get-watched-history) the ''type'' parameter supports two more strings: "shows" and "seasons".