### PR TITLE
Changed type of HistoryEntry 'id' field to a Long since it can be lon…

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/HistoryEntry.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/HistoryEntry.java
@@ -4,7 +4,7 @@ import org.joda.time.DateTime;
 
 public class HistoryEntry {
 
-    public Integer id;
+    public Long id;
     public DateTime watched_at;
     public String action;
     public String type;


### PR DESCRIPTION
…ger than an Integer's max value and will cause a crash when parsing.