### PR TITLE
Added missing fields runtime and comment_count

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/Episode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Episode.java
@@ -11,5 +11,8 @@ public class Episode extends BaseEntity {
     // extended info
     public Integer number_abs;
     public OffsetDateTime first_aired;
+    public Integer comment_count;
+    public Integer runtime;
+    
 
 }

--- a/src/test/java/com/uwetrottmann/trakt5/services/EpisodesTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/EpisodesTest.java
@@ -26,6 +26,8 @@ public class EpisodesTest extends BaseTestCase {
         assertThat(episode.ids.imdb).isEqualTo(TestData.EPISODE_IMDB_ID);
         assertThat(episode.ids.tmdb).isEqualTo(TestData.EPISODE_TMDB_ID);
         assertThat(episode.ids.tvdb).isEqualTo(TestData.EPISODE_TVDB_ID);
+        assertThat(episode.runtime).isGreaterThan(0);
+        assertThat(episode.comment_count).isGreaterThanOrEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
Both runtime and comment_count are part of the extended summary provided when querying the episodes endpoint. 