### PR TITLE
64-bit integer bugfix

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncErrors.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncErrors.java
@@ -8,6 +8,6 @@ public class SyncErrors {
     public List<SyncShow> shows;
     public List<SyncSeason> seasons;
     public List<SyncEpisode> episodes;
-    public List<Integer> ids;
+    public List<Long> ids;
 
 }


### PR DESCRIPTION
According to https://trakt.docs.apiary.io/#reference/sync/remove-from-history/remove-items-from-history, the returned ids are 64-bit integers. To avoid `NumberFormatExceptions`, `Long` must be used