### PR TITLE
Add support for `last_updated_at` field

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseMovie.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseMovie.java
@@ -8,6 +8,7 @@ public class BaseMovie {
 
     public OffsetDateTime collected_at;
     public OffsetDateTime last_watched_at;
+    public OffsetDateTime last_updated_at;
     public OffsetDateTime listed_at;
     public int plays;
 

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseShow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseShow.java
@@ -18,6 +18,7 @@ public class BaseShow {
     /** watched */
     public Integer plays;
     public OffsetDateTime last_watched_at;
+    public OffsetDateTime last_updated_at;
     /** progress */
     public Integer aired;
     public Integer completed;

--- a/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
@@ -150,6 +150,7 @@ public class BaseTestCase {
                 case "watched":
                     assertThat(movie.plays).isPositive();
                     assertThat(movie.last_watched_at).isNotNull();
+                    assertThat(movie.last_updated_at).isNotNull();
                     break;
                 case "watchlist":
                     assertThat(movie.listed_at).isNotNull();
@@ -166,6 +167,7 @@ public class BaseTestCase {
             } else if ("watched".equals(type)) {
                 assertThat(show.plays).isPositive();
                 assertThat(show.last_watched_at).isNotNull();
+                assertThat(show.last_updated_at).isNotNull();
             }
 
             for (BaseSeason season : show.seasons) {

--- a/src/test/java/com/uwetrottmann/trakt5/services/ShowsTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/ShowsTest.java
@@ -155,6 +155,7 @@ public class ShowsTest extends BaseTestCase {
     private void assertWatchedProgress(BaseShow show) {
         assertThat(show).isNotNull();
         assertThat(show.last_watched_at).isNotNull();
+        assertThat(show.last_updated_at).isNotNull();
         assertProgress(show);
     }
 


### PR DESCRIPTION
Useful for syncing watched shows and movies efficiently. See the API docs
https://trakt.docs.apiary.io/#reference/sync/get-watched