### PR TITLE
Add scrobble and getPlayback sync capabilities.

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/TraktV2.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktV2.java
@@ -17,6 +17,8 @@ import com.uwetrottmann.trakt5.services.Seasons;
 import com.uwetrottmann.trakt5.services.Shows;
 import com.uwetrottmann.trakt5.services.Sync;
 import com.uwetrottmann.trakt5.services.Users;
+import com.uwetrottmann.trakt5.services.Scrobble;
+
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import retrofit2.Converter;
@@ -371,6 +373,8 @@ public class TraktV2 {
     public Sync sync() {
         return retrofit().create(Sync.class);
     }
+
+    public Scrobble scrobble() { return retrofit().create(Scrobble.class); }
 
     public Users users() {
         return retrofit().create(Users.class);

--- a/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeProgress.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeProgress.java
@@ -1,0 +1,6 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class EpisodeProgress extends Progress {
+    public SyncEpisode episode;
+    public String type = "episode";
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/GenericProgress.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/GenericProgress.java
@@ -1,0 +1,8 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class GenericProgress extends Progress {
+    public SyncEpisode episode;
+    public SyncShow show;
+    public SyncMovie movie;
+    public String type;
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/MovieProgress.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/MovieProgress.java
@@ -1,0 +1,6 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class MovieProgress extends Progress {
+    public SyncMovie movie;
+    public String type = "movie";
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Progress.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Progress.java
@@ -1,0 +1,5 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class Progress {
+    public float progress = 0;
+}

--- a/src/main/java/com/uwetrottmann/trakt5/services/Scrobble.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Scrobble.java
@@ -1,0 +1,40 @@
+package com.uwetrottmann.trakt5.services;
+
+import com.uwetrottmann.trakt5.entities.GenericProgress;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
+
+public interface Scrobble {
+	/**
+     * <b>OAuth Required</b>
+     *
+     * <p> User starts a video
+     */
+    @POST("scrobble/start")
+    Call<Void> startWatching(
+            @Body GenericProgress prog
+    );
+
+    /**
+     * <b>OAuth Required</b>
+     *
+     * <p> User pauses a video
+     */
+    @POST("scrobble/pause")
+    Call<Void> pauseWatching(
+            @Body GenericProgress prog
+    );
+
+	/**
+     * <b>OAuth Required</b>
+     *
+     * <p> User stops a video
+     */
+    @POST("scrobble/stop")
+    Call<Void> stopWatching(
+            @Body GenericProgress prog
+    );
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/services/Sync.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Sync.java
@@ -2,7 +2,9 @@ package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.BaseMovie;
 import com.uwetrottmann.trakt5.entities.BaseShow;
+import com.uwetrottmann.trakt5.entities.GenericProgress;
 import com.uwetrottmann.trakt5.entities.LastActivities;
+import com.uwetrottmann.trakt5.entities.Progress;
 import com.uwetrottmann.trakt5.entities.RatedEpisode;
 import com.uwetrottmann.trakt5.entities.RatedMovie;
 import com.uwetrottmann.trakt5.entities.RatedSeason;
@@ -89,6 +91,14 @@ public interface Sync {
     Call<List<BaseMovie>> watchedMovies(
             @Query(value = "extended", encoded = true) Extended extended
     );
+
+    /**
+     * <b>OAuth Required</b>
+     *
+     * <p> Returns all playbacks;
+     */
+    @GET("sync/playback")
+    Call<List<GenericProgress>> getPlayback();
 
     /**
      * <b>OAuth Required</b>


### PR DESCRIPTION
Add scrobble to track video playback progress and sync playback status to retrieve the current resume points.
This is used both in Nova and Archos Video Player to sync resume bookmarks in a distributed devices context. 
No test written for now (sorry).