### PR TITLE
Update show progress endpoints to provide the last episode watched/collected

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/TraktV2Helper.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktV2Helper.java
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
+import com.uwetrottmann.trakt5.enums.ProgressLastActivity;
 import com.uwetrottmann.trakt5.enums.ListPrivacy;
 import com.uwetrottmann.trakt5.enums.Rating;
 import com.uwetrottmann.trakt5.enums.SortBy;
@@ -48,6 +49,10 @@ public class TraktV2Helper {
         // status
         builder.registerTypeAdapter(Status.class,
                 (JsonDeserializer<Status>) (json, typeOfT, context) -> Status.fromValue(json.getAsString()));
+
+        // progress last activity
+        builder.registerTypeAdapter(ProgressLastActivity.class,
+                (JsonDeserializer<ProgressLastActivity>) (json, typeOfT, context) -> ProgressLastActivity.fromValue(json.getAsString()));
 
         return builder;
     }

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseShow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseShow.java
@@ -19,10 +19,12 @@ public class BaseShow {
     public Integer plays;
     public OffsetDateTime last_watched_at;
     public OffsetDateTime last_updated_at;
+    public OffsetDateTime reset_at;
     /** progress */
     public Integer aired;
     public Integer completed;
     public List<Season> hidden_seasons;
     public Episode next_episode;
+    public Episode last_episode;
 
 }

--- a/src/main/java/com/uwetrottmann/trakt5/enums/ProgressLastActivity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/ProgressLastActivity.java
@@ -1,0 +1,35 @@
+package com.uwetrottmann.trakt5.enums;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public enum ProgressLastActivity implements TraktEnum {
+
+    COLLECTED("collected"),
+    WATCHED("watched");
+
+    private final String value;
+
+    ProgressLastActivity(String value) {
+        this.value = value;
+    }
+
+    private static final Map<String, ProgressLastActivity> STRING_MAPPING = new HashMap<>();
+
+    static {
+        for (ProgressLastActivity via : ProgressLastActivity.values()) {
+            STRING_MAPPING.put(via.toString().toUpperCase(Locale.ROOT), via);
+        }
+    }
+
+    public static ProgressLastActivity fromValue(String value) {
+        return STRING_MAPPING.get(value.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/services/Shows.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Shows.java
@@ -9,6 +9,7 @@ import com.uwetrottmann.trakt5.entities.Stats;
 import com.uwetrottmann.trakt5.entities.Translation;
 import com.uwetrottmann.trakt5.entities.TrendingShow;
 import com.uwetrottmann.trakt5.enums.Extended;
+import com.uwetrottmann.trakt5.enums.ProgressLastActivity;
 import retrofit2.Call;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
@@ -102,15 +103,33 @@ public interface Shows {
      * <p>By default, any hidden seasons will be removed from the response and stats. To include these and adjust the
      * completion stats, set the {@code hidden} flag to {@code true}.
      *
+     * <p>By default, specials will be excluded from the response. Set the {@code specials} flag to {@code true} to
+     * include season 0 and adjust the stats accordingly. If you'd like to include specials, but not adjust the stats,
+     * set {@code count_specials} to {@code false}.
+     *
+     * <p>By default, the {@code last_episode} and {@code next_episode} are calculated using the last {@code aired}
+     * episode the user has collected, even if they've collected older episodes more recently. To use their last
+     * collected episode for these calculations, set the {@code last_activity} flag to {@code collected}.
+     *
+     * <b>Note:</b>
+     *
+     * <p>Only aired episodes are used to calculate progress. Episodes in the future or without an air date are ignored.
+     *
      * @param showId trakt ID, trakt slug, or IMDB ID. Example: "game-of-thrones".
      * @param hidden Include any hidden seasons.
      * @param specials Include specials as season 0.
+     * @param countSpecials Count specials in the overall stats (only applies if specials are included)
+     * @param lastActivity By default, the last_episode and next_episode are calculated using the last aired episode the
+     * user has watched, even if they've watched older episodes more recently. To use their last watched episode for
+     * these calculations, set the last_activity flag to collected or watched respectively.
      */
     @GET("shows/{id}/progress/collection")
     Call<BaseShow> collectedProgress(
             @Path("id") String showId,
             @Query("hidden") Boolean hidden,
             @Query("specials") Boolean specials,
+            @Query("count_specials") Boolean countSpecials,
+            @Query("last_activity") ProgressLastActivity lastActivity,
             @Query(value = "extended", encoded = true) Extended extended
     );
 
@@ -119,19 +138,39 @@ public interface Shows {
      *
      * Returns watched progress for show including details on all seasons and episodes. The {@code next_episode} will be
      * the next episode the user should watch, if there are no upcoming episodes it will be set to {@code null}.
+     * If not {@code null}, the {@code reset_at} date is when the user started re-watching the show. Your app can adjust
+     * the progress by ignoring episodes with a {@code last_watched_at} prior to the {@code reset_at}.
      *
      * <p>By default, any hidden seasons will be removed from the response and stats. To include these and adjust the
      * completion stats, set the {@code hidden} flag to {@code true}.
      *
+     * <p>By default, specials will be excluded from the response. Set the {@code specials} flag to {@code true} to
+     * include season 0 and adjust the stats accordingly. If you'd like to include specials, but not adjust the stats,
+     * set {@code count_specials} to {@code false}.
+     *
+     * <p>By default, the {@code last_episode} and {@code next_episode} are calculated using the last {@code aired}
+     * episode the user has watched, even if they've watched older episodes more recently. To use their last watched
+     * episode for these calculations, set the {@code last_activity} flag to {@code watched}.
+     *
+     * <b>Note:</b>
+     *
+     * <p>Only aired episodes are used to calculate progress. Episodes in the future or without an air date are ignored.
+     *
      * @param showId trakt ID, trakt slug, or IMDB ID. Example: "game-of-thrones".
      * @param hidden Include any hidden seasons.
      * @param specials Include specials as season 0.
+     * @param countSpecials Count specials in the overall stats (only applies if specials are included)
+     * @param lastActivity By default, the last_episode and next_episode are calculated using the last aired episode the
+     * user has watched, even if they've watched older episodes more recently. To use their last watched episode for
+     * these calculations, set the last_activity flag to collected or watched respectively.
      */
     @GET("shows/{id}/progress/watched")
     Call<BaseShow> watchedProgress(
             @Path("id") String showId,
             @Query("hidden") Boolean hidden,
             @Query("specials") Boolean specials,
+            @Query("count_specials") Boolean countSpecials,
+            @Query("last_activity") ProgressLastActivity lastActivity,
             @Query(value = "extended", encoded = true) Extended extended
     );
 

--- a/src/test/java/com/uwetrottmann/trakt5/services/ShowsTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/ShowsTest.java
@@ -127,7 +127,7 @@ public class ShowsTest extends BaseTestCase {
     public void test_collected_progress() throws IOException {
         BaseShow show = executeCall(getTrakt()
                 .shows()
-                .collectedProgress(TestData.SHOW_SLUG, null, null, null)
+                .collectedProgress(TestData.SHOW_SLUG, null, null, null, null, null)
         );
 
         assertThat(show).isNotNull();
@@ -139,7 +139,7 @@ public class ShowsTest extends BaseTestCase {
     public void test_watched_progress() throws IOException {
         BaseShow show = executeCall(getTrakt()
                 .shows()
-                .watchedProgress(TestData.SHOW_SLUG, null, null, null)
+                .watchedProgress(TestData.SHOW_SLUG, null, null, null, null, null)
         );
 
         assertThat(show).isNotNull();
@@ -150,6 +150,11 @@ public class ShowsTest extends BaseTestCase {
     private void assertProgress(BaseShow show) {
         assertThat(show.aired).isGreaterThan(30);
         assertThat(show.completed).isGreaterThanOrEqualTo(1);
+        assertThat(show.last_episode).isNotNull();
+
+        // show progress not complete
+        assertThat(show.completed).isLessThan(show.aired);
+        assertThat(show.next_episode).isNotNull();
 
         // Killjoys has 5 aired seasons
         assertThat(show.seasons).isNotNull();


### PR DESCRIPTION
The [API Blog](https://apiblog.trakt.tv/api-changelog-9f4041819718) post for January 25, 2019 describes the last_activity parameter.

The [API Docs](https://trakt.docs.apiary.io/#reference/shows/watched-progress/get-show-watched-progress) parameters haven't been updated but the description mentions it.