### PR TITLE
Added OAuth Device Code Authentication

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/AccessToken.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/AccessToken.java
@@ -7,5 +7,6 @@ public class AccessToken {
     public Integer expires_in;
     public String refresh_token;
     public String scope;
+    public Integer created_at;
 
 }

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ClientId.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ClientId.java
@@ -1,0 +1,7 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class ClientId {
+
+    public String client_id;
+    
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCode.java
@@ -1,0 +1,11 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class DeviceCode {
+
+    public String device_code;
+    public String user_code;
+    public String verification_url;
+    public Integer expires_in;
+    public Integer interval;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCodeAccessTokenRequest.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCodeAccessTokenRequest.java
@@ -1,0 +1,9 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class DeviceCodeAccessTokenRequest {
+
+    public String code;
+    public String client_id;
+    public String client_secret;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/services/Authentication.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Authentication.java
@@ -2,7 +2,11 @@ package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.TraktV2;
 import com.uwetrottmann.trakt5.entities.AccessToken;
+import com.uwetrottmann.trakt5.entities.ClientId;
+import com.uwetrottmann.trakt5.entities.DeviceCode;
+import com.uwetrottmann.trakt5.entities.DeviceCodeAccessTokenRequest;
 import retrofit2.Call;
+import retrofit2.http.Body;
 import retrofit2.http.Field;
 import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.POST;
@@ -27,6 +31,34 @@ public interface Authentication {
             @Field("client_id") String clientId,
             @Field("client_secret") String clientSecret,
             @Field("redirect_uri") String redirectUri
+    );
+
+    /**
+     * Generate new codes to start the device authentication process.
+     * The {@code device_code} and {@code interval} will be used later to poll for the {@code access_token}.
+     * The {@code user_code} and {@code verification_url} should be presented to the user.
+     * @param clientId Application Client Id
+     */
+    @POST(TraktV2.OAUTH2_DEVICE_CODE_URL)
+    Call<DeviceCode> generateDeviceCode(
+            @Body ClientId clientId
+    );
+
+    /**
+     * Use the {@code device_code} and poll at the {@code interval} (in seconds) to check if the user has
+     * authorized you app. Use {@code expires_in} to stop polling after that many seconds, and gracefully
+     * instruct the user to restart the process.
+     * <b>It is important to poll at the correct interval and also stop polling when expired.</b>
+     *
+     * When you receive a {@code 200} success response, save the {@code access_token} so your app can
+     * authenticate the user in methods that require it. The {@code access_token} is valid for 3 months.
+     * Save and use the {@code refresh_token} to get a new {@code access_token} without asking the user
+     * to re-authenticate.
+     * @param deviceCodeAccessTokenRequest Device Code
+     */
+    @POST(TraktV2.OAUTH2_DEVICE_TOKEN_URL)
+    Call<AccessToken> exchangeDeviceCodeForAccessToken(
+            @Body DeviceCodeAccessTokenRequest deviceCodeAccessTokenRequest
     );
 
 }

--- a/src/test/java/com/uwetrottmann/trakt5/AuthTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/AuthTest.java
@@ -63,15 +63,4 @@ public class AuthTest extends BaseTestCase {
         assertAccessTokenResponse(response);
     }
 
-    private void assertAccessTokenResponse(Response<AccessToken> response) {
-        assertSuccessfulResponse(response);
-        assertThat(response.body().access_token).isNotEmpty();
-        assertThat(response.body().refresh_token).isNotEmpty();
-
-        System.out.println("Retrieved access token: " + response.body().access_token);
-        System.out.println("Retrieved refresh token: " + response.body().refresh_token);
-        System.out.println("Retrieved scope: " + response.body().scope);
-        System.out.println("Retrieved expires in: " + response.body().expires_in + " seconds");
-    }
-
 }

--- a/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
@@ -244,6 +244,8 @@ public class BaseTestCase {
         assertSuccessfulResponse(response);
         assertThat(response.body().access_token).isNotEmpty();
         assertThat(response.body().refresh_token).isNotEmpty();
+        assertThat(response.body().created_at).isPositive();
+        assertThat(response.body().expires_in).isPositive();
 
         System.out.println("Retrieved access token: " + response.body().access_token);
         System.out.println("Retrieved refresh token: " + response.body().refresh_token);

--- a/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
@@ -1,5 +1,6 @@
 package com.uwetrottmann.trakt5;
 
+import com.uwetrottmann.trakt5.entities.AccessToken;
 import com.uwetrottmann.trakt5.entities.BaseEpisode;
 import com.uwetrottmann.trakt5.entities.BaseMovie;
 import com.uwetrottmann.trakt5.entities.BaseRatedEntity;
@@ -237,6 +238,17 @@ public class BaseTestCase {
                 assertThat(crewMember.person).isNotNull();
             }
         }
+    }
+
+    protected void assertAccessTokenResponse(Response<AccessToken> response) {
+        assertSuccessfulResponse(response);
+        assertThat(response.body().access_token).isNotEmpty();
+        assertThat(response.body().refresh_token).isNotEmpty();
+
+        System.out.println("Retrieved access token: " + response.body().access_token);
+        System.out.println("Retrieved refresh token: " + response.body().refresh_token);
+        System.out.println("Retrieved scope: " + response.body().scope);
+        System.out.println("Retrieved expires in: " + response.body().expires_in + " seconds");
     }
 
 }

--- a/src/test/java/com/uwetrottmann/trakt5/DeviceAuthTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/DeviceAuthTest.java
@@ -1,0 +1,63 @@
+package com.uwetrottmann.trakt5;
+
+import com.uwetrottmann.trakt5.entities.AccessToken;
+import com.uwetrottmann.trakt5.entities.DeviceCode;
+import org.junit.Test;
+import retrofit2.Response;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test should NOT be run with the regular test suite. It requires a valid, temporary (!) auth code to be set.
+ */
+public class DeviceAuthTest extends BaseTestCase {
+
+    private static final String TEST_CLIENT_SECRET = "";
+    private static final String TEST_DEVICE_CODE = "";
+    // The Redirect URI is not used in OAuth device authentication.
+    // Set the default as the out-of-band URI used during standard OAuth.
+    private static final String TEST_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
+
+    private static final TraktV2 trakt = new TestTraktV2(TEST_CLIENT_ID, TEST_CLIENT_SECRET, TEST_REDIRECT_URI);
+
+    @Override
+    protected TraktV2 getTrakt() {
+        return trakt;
+    }
+
+    @Test
+    public void test_generateDeviceCode() throws IOException {
+        if (TEST_CLIENT_ID.isEmpty()) {
+            System.out.print("Skipping test_generateDeviceCode test, no valid client id");
+            return;
+        }
+
+        Response<DeviceCode> codeResponse = getTrakt().generateDeviceCode();
+        assertSuccessfulResponse(codeResponse);
+        DeviceCode deviceCode = codeResponse.body();
+        assertThat(deviceCode.device_code).isNotEmpty();
+        assertThat(deviceCode.user_code).isNotEmpty();
+        assertThat(deviceCode.verification_url).isNotEmpty();
+        assertThat(deviceCode.expires_in).isPositive();
+        assertThat(deviceCode.interval).isPositive();
+
+        System.out.println("Device Code: " + deviceCode.device_code);
+        System.out.println("User Code: " + deviceCode.user_code);
+        System.out.println("Enter the user code at the following URI: " + deviceCode.verification_url);
+        System.out.println("Set the TEST_DEVICE_CODE variable to run the access token test");
+    }
+
+    @Test
+    public void test_getAccessToken() throws IOException {
+        if (TEST_CLIENT_SECRET.isEmpty() || TEST_DEVICE_CODE.isEmpty()) {
+            System.out.print("Skipping test_getAccessToken test, no valid auth data");
+            return;
+        }
+
+        Response<AccessToken> response = getTrakt().exchangeDeviceCodeForAccessToken(TEST_DEVICE_CODE);
+        assertAccessTokenResponse(response);
+    }
+
+}


### PR DESCRIPTION
Device Authentication Flow

1. Application requests device codes from Trakt
2. Present the user with a URL to visit (https://trakt.tv/activate) and typically 8 digit code to enter.
3. Application polls token endpoint waiting for the user to authenticate with the code based on the intervals provided with the device code

