### PR TITLE
Add missing Audio types

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/enums/Audio.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Audio.java
@@ -7,9 +7,12 @@ public enum Audio implements TraktEnum {
 
     LPCM("lpcm"),
     MP3("mp3"),
+    MP2("mp2"),
     AAC("aac"),
     OGG("ogg"),
+    OGG_OPUS("ogg_opus"),
     WMA("wma"),
+    FLAC("flac"),
     DTS("dts"),
     DTS_MA("dts_ma"),
     DTS_HR("dts_hr"),
@@ -17,6 +20,7 @@ public enum Audio implements TraktEnum {
     AURO_3D("auro_3d"),
     DOLBY_DIGITAL("dolby_digital"),
     DOLBY_DIGITAL_PLUS("dolby_digital_plus"),
+    DOLBY_DIGITAL_PLUS_ATMOS("dolby_digital_plus_atmos"),
     DOLBY_ATMOS("dolby_atmos"),
     DOLBY_TRUEHD("dolby_truehd"),
     DOLBY_PROLOGIC("dolby_prologic");


### PR DESCRIPTION
I found some audio formats listed in the Trakt docs (https://trakt.docs.apiary.io/#reference/sync/add-to-collection) which are not available in the Audio enum.

The order of the enum felt kind of random to me. If you want me to reorder it (say for instance alphabetically) or add the new ones at a different place let me know.