### PR TITLE
Add pagination query parameters to sync ratings endpoints

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/services/Sync.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Sync.java
@@ -165,11 +165,17 @@ public interface Sync {
      * <p> Get a user's ratings filtered by movies. You can filter for a specific rating between 1 and 10.
      *
      * @param filter Filter for a specific rating.
+     * @param page   Number of page of results to be returned. If {@code null} but {@code limit} is provided defaults to
+     *               1, otherwise items are paginated.
+     * @param limit  Number of results to return per page. If {@code null} but {@code page} is provided defaults to 10,
+     *               otherwise all items are returned.
      */
     @GET("sync/ratings/movies{rating}")
     Call<List<RatedMovie>> ratingsMovies(
             @Path(value = "rating", encoded = true) RatingsFilter filter,
-            @Query(value = "extended", encoded = true) Extended extended
+            @Query(value = "extended", encoded = true) Extended extended,
+            @Query("page") Integer page,
+            @Query("limit") Integer limit
     );
 
     /**
@@ -178,11 +184,17 @@ public interface Sync {
      * <p> Get a user's ratings filtered by shows. You can filter for a specific rating between 1 and 10.
      *
      * @param filter Filter for a specific rating.
+     * @param page   Number of page of results to be returned. If {@code null} but {@code limit} is provided defaults to
+     *               1, otherwise items are not paginated.
+     * @param limit  Number of results to return per page. If {@code null} but {@code page} is provided defaults to 10,
+     *               otherwise all items are returned.
      */
     @GET("sync/ratings/shows{rating}")
     Call<List<RatedShow>> ratingsShows(
             @Path(value = "rating", encoded = true) RatingsFilter filter,
-            @Query(value = "extended", encoded = true) Extended extended
+            @Query(value = "extended", encoded = true) Extended extended,
+            @Query("page") Integer page,
+            @Query("limit") Integer limit
     );
 
     /**
@@ -191,11 +203,17 @@ public interface Sync {
      * <p> Get a user's ratings filtered by seasons. You can filter for a specific rating between 1 and 10.
      *
      * @param filter Filter for a specific rating.
+     * @param page   Number of page of results to be returned. If {@code null} but {@code limit} is provided defaults to
+     *               1, otherwise items are paginated.
+     * @param limit  Number of results to return per page. If {@code null} but {@code page} is provided defaults to 10,
+     *               otherwise all items are returned.
      */
     @GET("sync/ratings/seasons{rating}")
     Call<List<RatedSeason>> ratingsSeasons(
             @Path(value = "rating", encoded = true) RatingsFilter filter,
-            @Query(value = "extended", encoded = true) Extended extended
+            @Query(value = "extended", encoded = true) Extended extended,
+            @Query("page") Integer page,
+            @Query("limit") Integer limit
     );
 
     /**
@@ -204,11 +222,17 @@ public interface Sync {
      * <p> Get a user's ratings filtered by episodes. You can filter for a specific rating between 1 and 10.
      *
      * @param filter Filter for a specific rating.
+     * @param page   Number of page of results to be returned. If {@code null} but {@code limit} is provided defaults to
+     *               1, otherwise items are paginated.
+     * @param limit  Number of results to return per page. If {@code null} but {@code page} is provided defaults to 10,
+     *               otherwise all items are returned.
      */
     @GET("sync/ratings/episodes{rating}")
     Call<List<RatedEpisode>> ratingsEpisodes(
             @Path(value = "rating", encoded = true) RatingsFilter filter,
-            @Query(value = "extended", encoded = true) Extended extended
+            @Query(value = "extended", encoded = true) Extended extended,
+            @Query("page") Integer page,
+            @Query("limit") Integer limit
     );
 
     /**

--- a/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
@@ -121,10 +121,10 @@ public class BaseTestCase {
         }
     }
 
-    protected static <T extends BaseRatedEntity> void assertRatedEntities(List<T> ratedMovies) {
-        for (BaseRatedEntity movie : ratedMovies) {
-            assertThat(movie.rated_at).isNotNull();
-            assertThat(movie.rating).isNotNull();
+    protected static <T extends BaseRatedEntity> void assertRatedEntities(List<T> ratedEntities) {
+        for (BaseRatedEntity ratedEntity : ratedEntities) {
+            assertThat(ratedEntity.rated_at).isNotNull();
+            assertThat(ratedEntity.rating).isNotNull();
         }
     }
 

--- a/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
+++ b/src/test/java/com/uwetrottmann/trakt5/BaseTestCase.java
@@ -92,6 +92,17 @@ public class BaseTestCase {
     }
 
     /**
+     * Execute call with non-Void response body, without extracting it.
+     */
+    public <T> Response<T> executeCallWithoutReadingBody(Call<T> call) throws IOException {
+        Response<T> response = call.execute();
+        if (!response.isSuccessful()) {
+            handleFailedResponse(response); // will throw error
+        }
+        return response;
+    }
+
+    /**
      * Execute call with Void response body.
      */
     public <T> void executeVoidCall(Call<T> call) throws IOException {

--- a/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
@@ -313,15 +313,14 @@ public class SyncTest extends BaseTestCase {
 
     @Test
     public void test_ratingsMovies() throws IOException {
-        List<RatedMovie> ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.ALL,
-                null));
+        List<RatedMovie> ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.ALL, null, 1, 2));
         assertRatedEntities(ratedMovies);
     }
 
     @Test
     public void test_ratingsMovies_filtered() throws IOException {
         List<RatedMovie> ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.TOTALLYNINJA,
-                null));
+                null, null, null));
         assertThat(ratedMovies).isNotNull();
         for (RatedMovie movie : ratedMovies) {
             assertThat(movie.rated_at).isNotNull();
@@ -330,24 +329,64 @@ public class SyncTest extends BaseTestCase {
     }
 
     @Test
+    public void test_ratingsMovies_with_pagination() throws IOException {
+        List<RatedMovie> ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.ALL, null, 1, 2));
+        assertThat(ratedMovies).hasSize(2);
+        assertRatedEntities(ratedMovies);
+        ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.ALL, null, 2, 2));
+        assertThat(ratedMovies).hasSize(2);
+        assertRatedEntities(ratedMovies);
+    }
+
+    @Test
     public void test_ratingsShows() throws IOException {
-        List<RatedShow> ratedShows = executeCall(getTrakt().sync().ratingsShows(RatingsFilter.ALL,
-                null));
+        List<RatedShow> ratedShows = executeCall(getTrakt().sync().ratingsShows(RatingsFilter.ALL, null, null, null));
+        assertRatedEntities(ratedShows);
+    }
+
+    @Test
+    public void test_ratingsShows_with_pagination() throws IOException {
+        List<RatedShow> ratedShows = executeCall(getTrakt().sync().ratingsShows(RatingsFilter.ALL, null, 1, 2));
+        assertThat(ratedShows).hasSize(2);
+        assertRatedEntities(ratedShows);
+        ratedShows = executeCall(getTrakt().sync().ratingsShows(RatingsFilter.ALL, null, 2, 2));
+        assertThat(ratedShows).hasSize(2);
         assertRatedEntities(ratedShows);
     }
 
     @Test
     public void test_ratingsSeasons() throws IOException {
-        List<RatedSeason> ratedSeasons = executeCall(getTrakt().sync().ratingsSeasons(RatingsFilter.ALL,
+        List<RatedSeason> ratedSeasons = executeCall(getTrakt().sync().ratingsSeasons(RatingsFilter.ALL, null, null,
                 null));
         assertRatedEntities(ratedSeasons);
     }
 
     @Test
+    public void test_ratingsSeasons_with_pagination() throws IOException {
+        List<RatedSeason> ratedSeasons = executeCall(getTrakt().sync().ratingsSeasons(RatingsFilter.ALL, null, 1, 2));
+        assertRatedEntities(ratedSeasons);
+        assertThat(ratedSeasons).hasSize(2);
+        ratedSeasons = executeCall(getTrakt().sync().ratingsSeasons(RatingsFilter.ALL, null, 2, 2));
+        assertRatedEntities(ratedSeasons);
+        assertThat(ratedSeasons).hasSize(2);
+    }
+
+    @Test
     public void test_ratingsEpisodes() throws IOException {
-        List<RatedEpisode> ratedEpisodes = executeCall(getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL,
+        List<RatedEpisode> ratedEpisodes = executeCall(getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL, null, null,
                 null));
         assertRatedEntities(ratedEpisodes);
+    }
+
+    @Test
+    public void test_ratingsEpisodes_with_pagination() throws IOException {
+        List<RatedEpisode> ratedEpisodes = executeCall(getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL, null,
+                1, 2));
+        assertRatedEntities(ratedEpisodes);
+        assertThat(ratedEpisodes).hasSize(2);
+        ratedEpisodes = executeCall(getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL, null, 2, 2));
+        assertRatedEntities(ratedEpisodes);
+        assertThat(ratedEpisodes).hasSize(2);
     }
 
     @Test

--- a/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import org.threeten.bp.Instant;
 import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.ZoneOffset;
+import retrofit2.Call;
+import retrofit2.Response;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -88,7 +90,7 @@ public class SyncTest extends BaseTestCase {
                 assertThat(playback.paused_at).isNotNull();
                 assertThat(playback.progress).isEqualTo(25.0);
             }
-            
+
             if (playback.movie != null && playback.movie.ids != null && playback.movie.ids.tmdb != null
                     && playback.movie.ids.tmdb == interstellar) {
                 foundMovie = true;
@@ -330,12 +332,10 @@ public class SyncTest extends BaseTestCase {
 
     @Test
     public void test_ratingsMovies_with_pagination() throws IOException {
-        List<RatedMovie> ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.ALL, null, 1, 2));
-        assertThat(ratedMovies).hasSize(2);
-        assertRatedEntities(ratedMovies);
-        ratedMovies = executeCall(getTrakt().sync().ratingsMovies(RatingsFilter.ALL, null, 2, 2));
-        assertThat(ratedMovies).hasSize(2);
-        assertRatedEntities(ratedMovies);
+        Call<List<RatedMovie>> call = getTrakt().sync().ratingsMovies(RatingsFilter.ALL, null, 1, 2);
+        Response<List<RatedMovie>> response = executeCallWithoutReadingBody(call);
+        assertThat(response.headers().get("X-Pagination-Page-Count")).isNotEmpty();
+        assertThat(response.headers().get("X-Pagination-Item-Count")).isNotEmpty();
     }
 
     @Test
@@ -346,12 +346,10 @@ public class SyncTest extends BaseTestCase {
 
     @Test
     public void test_ratingsShows_with_pagination() throws IOException {
-        List<RatedShow> ratedShows = executeCall(getTrakt().sync().ratingsShows(RatingsFilter.ALL, null, 1, 2));
-        assertThat(ratedShows).hasSize(2);
-        assertRatedEntities(ratedShows);
-        ratedShows = executeCall(getTrakt().sync().ratingsShows(RatingsFilter.ALL, null, 2, 2));
-        assertThat(ratedShows).hasSize(2);
-        assertRatedEntities(ratedShows);
+        Call<List<RatedShow>> call = getTrakt().sync().ratingsShows(RatingsFilter.ALL, null, 1, 2);
+        Response<List<RatedShow>> response = executeCallWithoutReadingBody(call);
+        assertThat(response.headers().get("X-Pagination-Page-Count")).isNotEmpty();
+        assertThat(response.headers().get("X-Pagination-Item-Count")).isNotEmpty();
     }
 
     @Test
@@ -363,12 +361,10 @@ public class SyncTest extends BaseTestCase {
 
     @Test
     public void test_ratingsSeasons_with_pagination() throws IOException {
-        List<RatedSeason> ratedSeasons = executeCall(getTrakt().sync().ratingsSeasons(RatingsFilter.ALL, null, 1, 2));
-        assertRatedEntities(ratedSeasons);
-        assertThat(ratedSeasons).hasSize(2);
-        ratedSeasons = executeCall(getTrakt().sync().ratingsSeasons(RatingsFilter.ALL, null, 2, 2));
-        assertRatedEntities(ratedSeasons);
-        assertThat(ratedSeasons).hasSize(2);
+        Call<List<RatedSeason>> call = getTrakt().sync().ratingsSeasons(RatingsFilter.ALL, null, 1, 5);
+        Response<List<RatedSeason>> response = executeCallWithoutReadingBody(call);
+        assertThat(response.headers().get("X-Pagination-Page-Count")).isNotEmpty();
+        assertThat(response.headers().get("X-Pagination-Item-Count")).isNotEmpty();
     }
 
     @Test
@@ -380,13 +376,10 @@ public class SyncTest extends BaseTestCase {
 
     @Test
     public void test_ratingsEpisodes_with_pagination() throws IOException {
-        List<RatedEpisode> ratedEpisodes = executeCall(getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL, null,
-                1, 2));
-        assertRatedEntities(ratedEpisodes);
-        assertThat(ratedEpisodes).hasSize(2);
-        ratedEpisodes = executeCall(getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL, null, 2, 2));
-        assertRatedEntities(ratedEpisodes);
-        assertThat(ratedEpisodes).hasSize(2);
+        Call<List<RatedEpisode>> call = getTrakt().sync().ratingsEpisodes(RatingsFilter.ALL, null, 1, 2);
+        Response<List<RatedEpisode>> response = executeCallWithoutReadingBody(call);
+        assertThat(response.headers().get("X-Pagination-Page-Count")).isNotEmpty();
+        assertThat(response.headers().get("X-Pagination-Item-Count")).isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
Add pagination query parameters to sync ratings endpoints like discussed in #123