### PR TITLE
Add limits to user settings

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/Limits.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Limits.java
@@ -1,0 +1,9 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class Limits {
+
+    public ListLimits list;
+    public WatchlistLimits watchlist;
+    public RecommendationLimits recommendations;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListLimits.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListLimits.java
@@ -1,0 +1,8 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class ListLimits {
+
+    public int count;
+    public int item_count;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/RecommendationLimits.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/RecommendationLimits.java
@@ -1,0 +1,7 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class RecommendationLimits {
+
+    public int item_count;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Settings.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Settings.java
@@ -6,5 +6,6 @@ public class Settings {
     public Account account;
     public Connections connections;
     public SharingText sharing_text;
+    public Limits limits;
 
 }

--- a/src/main/java/com/uwetrottmann/trakt5/entities/WatchlistLimits.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/WatchlistLimits.java
@@ -1,0 +1,7 @@
+package com.uwetrottmann.trakt5.entities;
+
+public class WatchlistLimits {
+
+    public int item_count;
+
+}

--- a/src/test/java/com/uwetrottmann/trakt5/services/UsersTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/UsersTest.java
@@ -60,6 +60,7 @@ public class UsersTest extends BaseTestCase {
         assertThat(settings.account).isNotNull();
         assertThat(settings.connections).isNotNull();
         assertThat(settings.sharing_text).isNotNull();
+        assertThat(settings.limits).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
I've added limits to `Settings`, which show the maximum number of items in lists/maximum number of lists. I am not sure about the naming of the added classes, let me know if I should change them!

Documentation: https://trakt.docs.apiary.io/#reference/users/settings/retrieve-settings

Context: If requests are failing with status code 420, the user reached the above limits.