### PR TITLE
Add method to reorder user's lists

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/services/Users.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Users.java
@@ -135,6 +135,17 @@ public interface Users {
     );
 
     /**
+     * <b>OAuth Required</b>
+     *
+     * <p> Reorder all custom lists by sending the updated rank of list ids.
+     */
+    @POST("users/{username}/lists/reorder")
+    Call<ListReorderResponse> reorderLists(
+            @Path("username") UserSlug userSlug,
+            @Body ListItemRank rank
+    );
+
+    /**
      * <b>OAuth Optional</b>
      *
      * <p> Get all items on a custom list. Items can be movies, shows, seasons, episodes, or people.

--- a/src/test/java/com/uwetrottmann/trakt5/services/UsersTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/UsersTest.java
@@ -218,6 +218,23 @@ public class UsersTest extends BaseTestCase {
     }
 
     @Test
+    public void test_reorderLists() throws IOException {
+        List<TraktList> lists = executeCall(getTrakt().users().lists(UserSlug.ME));
+
+        // reverse order
+        List<Long> newRank = new ArrayList<>();
+        for (int i = lists.size() - 1; i >= 0; i--) {
+            newRank.add(lists.get(i).ids.trakt.longValue());
+        }
+
+        ListReorderResponse response = executeCall(getTrakt().users().reorderLists(
+                UserSlug.ME,
+                ListItemRank.from(newRank)
+        ));
+        assertThat(response.updated).isEqualTo(lists.size());
+    }
+
+    @Test
     public void test_unfollowAndFollow() throws InterruptedException, IOException {
         // unfollow first
         UserSlug userToFollow = new UserSlug(TestData.USER_TO_FOLLOW);


### PR DESCRIPTION
While reordering items within a user's list has already been supported, this PR adds the method to reorder all lists of the user, see [here](https://trakt.docs.apiary.io/#reference/users/reorder-lists/reorder-a-user's-lists)