### PR TITLE
License: add missing headers required by Apache 2.0 license

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/TraktLink.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktLink.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5;
 
 /**

--- a/src/main/java/com/uwetrottmann/trakt5/TraktV2.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktV2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5;
 
 import com.uwetrottmann.trakt5.entities.AccessToken;

--- a/src/main/java/com/uwetrottmann/trakt5/TraktV2Authenticator.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktV2Authenticator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5;
 
 import com.uwetrottmann.trakt5.entities.AccessToken;

--- a/src/main/java/com/uwetrottmann/trakt5/TraktV2Helper.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktV2Helper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5;
 
 import com.google.gson.GsonBuilder;

--- a/src/main/java/com/uwetrottmann/trakt5/TraktV2Interceptor.java
+++ b/src/main/java/com/uwetrottmann/trakt5/TraktV2Interceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5;
 
 import okhttp3.Interceptor;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/AccessToken.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/AccessToken.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class AccessToken {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/AccessTokenRefreshRequest.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/AccessTokenRefreshRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class AccessTokenRefreshRequest {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/AccessTokenRequest.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/AccessTokenRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class AccessTokenRequest {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Account.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Account.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Account {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Airs.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Airs.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Airs {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseCheckin.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseCheckin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public abstract class BaseCheckin {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseCheckinResponse.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseCheckinResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseEntity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseEntity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseEpisode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseEpisode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public abstract class BaseIds {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseMovie.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseMovie.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseRatedEntity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseRatedEntity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.uwetrottmann.trakt5.enums.Rating;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseSeason.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseSeason.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import java.util.List;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseShow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseShow.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/BaseTrendingEntity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/BaseTrendingEntity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public abstract class BaseTrendingEntity {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/CalendarMovieEntry.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/CalendarMovieEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.LocalDate;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/CalendarShowEntry.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/CalendarShowEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/CastMember.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/CastMember.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class CastMember {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/CheckinError.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/CheckinError.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ClientId.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ClientId.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class ClientId {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Comment.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Comment.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Connections.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Connections.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Connections {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Credits.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Credits.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import java.util.List;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Crew.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Crew.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/CrewMember.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/CrewMember.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class CrewMember {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class DeviceCode {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCodeAccessTokenRequest.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/DeviceCodeAccessTokenRequest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class DeviceCodeAccessTokenRequest {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Episode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Episode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeCheckin.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeCheckin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeCheckinResponse.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeCheckinResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class EpisodeCheckinResponse extends BaseCheckinResponse {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/EpisodeIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Followed.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Followed.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Follower.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Follower.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Friend.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Friend.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/GenericProgress.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/GenericProgress.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public abstract class GenericProgress {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Genre.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Genre.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Genre {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/HistoryEntry.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/HistoryEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Images.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Images.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Images {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivities.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivities.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityMore.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityMore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListEntry.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListItemRank.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListItemRank.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListReorderResponse.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListReorderResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import java.util.List;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListsLastActivity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListsLastActivity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Metadata.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Metadata.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Movie.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Movie.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.LocalDate;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/MovieCheckin.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/MovieCheckin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/MovieCheckinResponse.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/MovieCheckinResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class MovieCheckinResponse extends BaseCheckinResponse {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/MovieIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/MovieIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/MovieTranslation.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/MovieTranslation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class MovieTranslation extends Translation {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Person.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Person.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.LocalDate;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/PersonIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/PersonIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/PlaybackResponse.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/PlaybackResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/RatedEpisode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/RatedEpisode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class RatedEpisode extends RatedShow {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/RatedMovie.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/RatedMovie.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class RatedMovie extends BaseRatedEntity {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/RatedSeason.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/RatedSeason.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class RatedSeason extends RatedShow {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/RatedShow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/RatedShow.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class RatedShow extends BaseRatedEntity {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Ratings.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Ratings.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import java.util.Map;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ScrobbleProgress.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ScrobbleProgress.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class ScrobbleProgress extends GenericProgress {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SearchResult.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SearchResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class SearchResult {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Season.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Season.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SeasonIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SeasonIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class SeasonIds {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Settings.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Settings.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Settings {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ShareSettings.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ShareSettings.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class ShareSettings {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SharingText.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SharingText.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class SharingText {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Show.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Show.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.uwetrottmann.trakt5.enums.Status;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ShowIds.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ShowIds.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Stats.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Stats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Stats {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncEpisode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncEpisode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncErrors.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncErrors.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import java.util.List;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncItems.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncItems.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncMovie.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncMovie.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncPerson.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncPerson.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncResponse.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncResponse.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class SyncResponse {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncSeason.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncSeason.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.uwetrottmann.trakt5.enums.Rating;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncShow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncShow.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.uwetrottmann.trakt5.enums.Rating;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/SyncStats.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/SyncStats.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class SyncStats {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/TraktError.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/TraktError.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nullable;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/TraktList.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/TraktList.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.uwetrottmann.trakt5.enums.ListPrivacy;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/TraktOAuthError.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/TraktOAuthError.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nullable;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/Translation.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/Translation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class Translation {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/TrendingMovie.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/TrendingMovie.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class TrendingMovie extends BaseTrendingEntity {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/TrendingShow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/TrendingShow.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 public class TrendingShow extends BaseTrendingEntity {

--- a/src/main/java/com/uwetrottmann/trakt5/entities/User.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/User.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/UserSlug.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/UserSlug.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/WatchlistedEpisode.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/WatchlistedEpisode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/WatchlistedSeason.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/WatchlistedSeason.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;

--- a/src/main/java/com/uwetrottmann/trakt5/entities/package-info.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/package-info.java
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @com.uwetrottmann.trakt5.internal.EverythingIsNullable
 package com.uwetrottmann.trakt5.entities;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Audio.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Audio.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/AudioChannels.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/AudioChannels.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Extended.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Extended.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 /**

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Hdr.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Hdr.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/HistoryType.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/HistoryType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 public enum HistoryType implements TraktEnum {

--- a/src/main/java/com/uwetrottmann/trakt5/enums/IdType.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/IdType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 public enum IdType implements TraktEnum {

--- a/src/main/java/com/uwetrottmann/trakt5/enums/ListPrivacy.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/ListPrivacy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/MediaType.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/MediaType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/ProgressLastActivity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/ProgressLastActivity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Rating.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Rating.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 public enum Rating implements TraktEnum {

--- a/src/main/java/com/uwetrottmann/trakt5/enums/RatingsFilter.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/RatingsFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 public enum RatingsFilter implements TraktEnum {

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Resolution.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Resolution.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/SortBy.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/SortBy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/SortHow.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/SortHow.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import com.google.gson.annotations.SerializedName;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Status.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Status.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 import java.util.HashMap;

--- a/src/main/java/com/uwetrottmann/trakt5/enums/TraktEnum.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/TraktEnum.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 public interface TraktEnum {

--- a/src/main/java/com/uwetrottmann/trakt5/enums/Type.java
+++ b/src/main/java/com/uwetrottmann/trakt5/enums/Type.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.enums;
 
 public enum Type implements TraktEnum {

--- a/src/main/java/com/uwetrottmann/trakt5/internal/EverythingIsNonNull.java
+++ b/src/main/java/com/uwetrottmann/trakt5/internal/EverythingIsNonNull.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.internal;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/com/uwetrottmann/trakt5/internal/EverythingIsNullable.java
+++ b/src/main/java/com/uwetrottmann/trakt5/internal/EverythingIsNullable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.internal;
 
 import javax.annotation.Nullable;

--- a/src/main/java/com/uwetrottmann/trakt5/package-info.java
+++ b/src/main/java/com/uwetrottmann/trakt5/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * A Java wrapper around the trakt v2 API using retrofit 2.
  */

--- a/src/main/java/com/uwetrottmann/trakt5/services/Authentication.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Authentication.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.AccessToken;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Calendars.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Calendars.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.CalendarMovieEntry;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Checkin.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Checkin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.EpisodeCheckin;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Comments.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Comments.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Comment;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Episodes.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Episodes.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Comment;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Genres.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Genres.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Genre;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Movies.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Movies.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Comment;

--- a/src/main/java/com/uwetrottmann/trakt5/services/People.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/People.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Credits;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Recommendations.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Recommendations.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Movie;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Scrobble.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Scrobble.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.PlaybackResponse;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Search.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Search.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.SearchResult;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Seasons.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Seasons.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.Comment;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Shows.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Shows.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.BaseShow;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Sync.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Sync.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.BaseMovie;

--- a/src/main/java/com/uwetrottmann/trakt5/services/Users.java
+++ b/src/main/java/com/uwetrottmann/trakt5/services/Users.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Uwe Trottmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.uwetrottmann.trakt5.services;
 
 import com.uwetrottmann.trakt5.entities.BaseMovie;


### PR DESCRIPTION
Kind of forgot all this time, here they are.