### PR TITLE
LastActivites: Add missing fields

### DIFF
--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivities.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivities.java
@@ -25,6 +25,12 @@ public class LastActivities {
     public LastActivityMore episodes;
     public LastActivity shows;
     public LastActivity seasons;
+    public LastActivityComments comments;
     public ListsLastActivity lists;
+    public LastActivityUpdated watchlist;
+    public LastActivityUpdated favorites;
+    public LastActivityAccount account;
+    public LastActivityUpdated saved_filters;
+    public LastActivityUpdated notes;
 
 }

--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityAccount.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityAccount.java
@@ -1,0 +1,13 @@
+package com.uwetrottmann.trakt5.entities;
+
+import org.threeten.bp.OffsetDateTime;
+
+public class LastActivityAccount {
+
+    public OffsetDateTime settings_at;
+    public OffsetDateTime followed_at;
+    public OffsetDateTime following_at;
+    public OffsetDateTime pending_at;
+    public OffsetDateTime requested_at;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityComments.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityComments.java
@@ -1,0 +1,10 @@
+package com.uwetrottmann.trakt5.entities;
+
+import org.threeten.bp.OffsetDateTime;
+
+public class LastActivityComments {
+
+    public OffsetDateTime liked_at;
+    public OffsetDateTime blocked_at;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityUpdated.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/LastActivityUpdated.java
@@ -1,0 +1,9 @@
+package com.uwetrottmann.trakt5.entities;
+
+import org.threeten.bp.OffsetDateTime;
+
+public class LastActivityUpdated {
+
+    public OffsetDateTime updated_at;
+
+}

--- a/src/main/java/com/uwetrottmann/trakt5/entities/ListsLastActivity.java
+++ b/src/main/java/com/uwetrottmann/trakt5/entities/ListsLastActivity.java
@@ -18,10 +18,9 @@ package com.uwetrottmann.trakt5.entities;
 
 import org.threeten.bp.OffsetDateTime;
 
-public class ListsLastActivity {
+public class ListsLastActivity extends LastActivityUpdated {
 
     public OffsetDateTime liked_at;
-    public OffsetDateTime updated_at;
     public OffsetDateTime commented_at;
 
 }

--- a/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
@@ -23,7 +23,10 @@ import com.uwetrottmann.trakt5.entities.BaseShow;
 import com.uwetrottmann.trakt5.entities.EpisodeIds;
 import com.uwetrottmann.trakt5.entities.LastActivities;
 import com.uwetrottmann.trakt5.entities.LastActivity;
+import com.uwetrottmann.trakt5.entities.LastActivityAccount;
+import com.uwetrottmann.trakt5.entities.LastActivityComments;
 import com.uwetrottmann.trakt5.entities.LastActivityMore;
+import com.uwetrottmann.trakt5.entities.LastActivityUpdated;
 import com.uwetrottmann.trakt5.entities.ListsLastActivity;
 import com.uwetrottmann.trakt5.entities.MovieIds;
 import com.uwetrottmann.trakt5.entities.PlaybackResponse;
@@ -68,7 +71,13 @@ public class SyncTest extends BaseTestCase {
         assertLastActivityMore(lastActivities.episodes);
         assertLastActivity(lastActivities.shows);
         assertLastActivity(lastActivities.seasons);
+        assertLastActivityComments(lastActivities.comments);
         assertListsLastActivity(lastActivities.lists);
+        assertLastActivityUpdated(lastActivities.watchlist);
+        assertLastActivityUpdated(lastActivities.favorites);
+        assertLastActivityAccount(lastActivities.account);
+        assertLastActivityUpdated(lastActivities.saved_filters);
+        assertLastActivityUpdated(lastActivities.notes);
     }
 
     @Test
@@ -139,6 +148,26 @@ public class SyncTest extends BaseTestCase {
         assertThat(activity).isNotNull();
         assertThat(activity.commented_at).isNotNull();
         assertThat(activity.liked_at).isNotNull();
+        assertThat(activity.updated_at).isNotNull();
+    }
+
+    private void assertLastActivityComments(LastActivityComments activity) {
+        assertThat(activity).isNotNull();
+        assertThat(activity.liked_at).isNotNull();
+        assertThat(activity.blocked_at).isNotNull();
+    }
+
+    private void assertLastActivityAccount(LastActivityAccount activity) {
+        assertThat(activity).isNotNull();
+        assertThat(activity.settings_at).isNotNull();
+        assertThat(activity.followed_at).isNotNull();
+        assertThat(activity.following_at).isNotNull();
+        assertThat(activity.pending_at).isNotNull();
+        assertThat(activity.requested_at).isNotNull();
+    }
+
+    private void assertLastActivityUpdated(LastActivityUpdated activity) {
+        assertThat(activity).isNotNull();
         assertThat(activity.updated_at).isNotNull();
     }
 


### PR DESCRIPTION
This PR adds the fields that are provided by the API but were not yet implemented in the LastActivities class.