### PR TITLE
Collection: assert pagination for shows

### DIFF
--- a/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/SyncTest.java
@@ -208,8 +208,7 @@ public class SyncTest extends BaseTestCase {
         Response<List<BaseShow>> response = executeCallWithoutReadingBody(
                 getTrakt().sync().collectionShows(PAGE_ONE, LIMIT_MAX, Extended.METADATA));
 
-        // As of 2026-03-06, when filtering to shows pagination appears to be not supported (yet?)
-        // assertListPaginationHeaders(response);
+        assertListPaginationHeaders(response);
         assertSyncShows(response.body(), "collection");
     }
 

--- a/src/test/java/com/uwetrottmann/trakt5/services/UsersTest.java
+++ b/src/test/java/com/uwetrottmann/trakt5/services/UsersTest.java
@@ -120,8 +120,7 @@ public class UsersTest extends BaseTestCase {
         Response<List<BaseShow>> response = executeCallWithoutReadingBody(
                 getTrakt().users().collectionShows(TestData.USER_SLUG, PAGE_ONE, LIMIT_MAX, null));
 
-        // As of 2026-03-06, when filtering to shows pagination appears to be not supported (yet?)
-        // assertListPaginationHeaders(response);
+        assertListPaginationHeaders(response);
         assertSyncShows(response.body(), "collection");
     }
 


### PR DESCRIPTION
Can't merge this, yet, as despite being announced in https://github.com/trakt/trakt-api/discussions/681

- collection endpoints don't support pagination, yet, **for shows**
- ~user lists items endpoints don't support sort orders, yet~ [actually works, only headers aren't updated as promised](https://github.com/UweTrottmann/trakt-java/pull/167#issuecomment-3964508443)

Last checked: 2026-05-08